### PR TITLE
Introduce wkhtmltopdf-0.12.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,8 @@ RUN apt-get update \
 
 # wkhtmltopdf needs a patched QT version
 RUN cd $TEMP_DIR \
-  && wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz \
-  && tar vxf wkhtmltox-0.12.3_linux-generic-amd64.tar.xz \
+  && wget https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O wkhtmltox.tar.xz \
+  && tar vxf wkhtmltox.tar.xz \
   && cp wkhtmltox/bin/wk* /usr/local/bin/ \
   && rm -rf $TEMP_DIR/wkhtml*
 


### PR DESCRIPTION
Hi,

I upgraded wkhtmltopdf to suggested version (@nilmerg said 0.12.4). In order not to break everything this was built into a new tag (0.19.6-wkhtmltopdf-0.12.4, manually built).

To change the image you need to override the image bash variable.