### PR TITLE
Update showoff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,21 +25,17 @@ RUN set -ex; \
       libfontconfig1-dev \
       libfreetype6-dev \
       fontconfig \
+      libjpeg-turbo8 \
+      xfonts-75dpi \
+      xfonts-base \
   && apt-get clean \
   && rm -r /var/lib/apt/lists/*
 
 # wkhtmltopdf needs a patched QT version
-ARG wkhtmltox_sha256_checksum="40bc014d0754ea44bb90e733f03e7c92862f7445ef581e3599ecc00711dddcaa"
-ARG wkhtmltox_url="https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz"
-
-# Download, verify and install wkhtmltox
+ADD vendor/wkhtmltox_0.12.5-1.focal_amd64.deb /tmp/wkhtmltox_0.12.5-1.focal_amd64.deb
 RUN set -ex; \
-    curl -sSL "${wkhtmltox_url}" --output /tmp/wkhtmltox.tar.xz\
-    && echo "${wkhtmltox_sha256_checksum}  /tmp/wkhtmltox.tar.xz" | sha256sum -c - \
-    \
-    && tar vxf /tmp/wkhtmltox.tar.xz -C /usr/local/bin/ --strip-components=2 wkhtmltox/bin/wkhtmltoimage \
-    && tar vxf /tmp/wkhtmltox.tar.xz -C /usr/local/bin/ --strip-components=2 wkhtmltox/bin/wkhtmltopdf \
-    && rm -f /tmp/wkhtmltox.tar.xz
+    dpkg -i /tmp/wkhtmltox_0.12.5-1.focal_amd64.deb \
+    && rm -f /tmp/wkhtmltox_0.12.5-1.focal_amd64.deb
 
 # Install showoff Gem
 ARG showoff_version=0.20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex; \
     && rm -f /tmp/wkhtmltox.tar.xz
 
 # Install showoff Gem
-ARG showoff_version=0.19.6
+ARG showoff_version=0.20.3
 RUN gem install showoff --version="$showoff_version"
 
 EXPOSE 9090

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,11 @@ RUN set -ex; \
 ARG showoff_version=0.20.3
 RUN gem install showoff --version="$showoff_version"
 
+ADD extras/showoff.patch /tmp/showoff.patch
+
+RUN cd /var/lib/gems/*/gems/showoff-*/lib \
+	&& patch -p1 < /tmp/showoff.patch
+
 EXPOSE 9090
 
 CMD ["showoff", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RUNTIME?=docker
-VERSION?=0.19.6
+VERSION?=0.20.3
 
 image:
 	$(RUNTIME) build --pull -t docker.io/netways/showoff:$(VERSION) .

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ make image RUNTIME=podman
 ### Run showoff
 
 ```bash
-docker run -it --rm -v "$PWD:/training" -p "9090:9090" netways/showoff:0.19.6
+docker run -it --rm -v "$PWD:/training" -p "9090:9090" netways/showoff:0.20.3
 ```
 
 ### Build static html files
 
 ```bash
-docker run -it --rm -v "$PWD:/training" netways/showoff:0.19.6 \
+docker run -it --rm -v "$PWD:/training" netways/showoff:0.20.3 \
   showoff static print
 ```
 
@@ -132,7 +132,7 @@ docker run -it --rm -v "$PWD:/training" netways/showoff:0.19.6 \
 
 ```bash
 docker run -it --rm -v "$PWD:/training" \
-  netways/showoff:0.19.6 \
+  netways/showoff:0.20.3 \
   wkhtmltopdf -s A5 --print-media-type \
   --footer-left \[page\] --footer-right '© NETWAYS' \
   static/index.html test.pdf

--- a/extras/showoff.patch
+++ b/extras/showoff.patch
@@ -1,0 +1,11 @@
+--- a/showoff.rb
++++ b/showoff.rb
+@@ -1810,7 +1810,7 @@ class Showoff < Sinatra::Application
+     end
+   end
+
+-  get %r{(?:image|file)/(.*)} do
++  get %r{/(?:image|file)/(.*)} do
+     path = params[:captures].first
+     full_path = File.join(settings.pres_dir, path)
+     if File.exist?(full_path)

--- a/wizard.sh
+++ b/wizard.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 DIR=$(pwd)
 CLANG=${CLANG:-C.UTF-8}
-IMAGE=${IMAGE:-netways/showoff:0.19.6}
+IMAGE=${IMAGE:-netways/showoff:0.20.3}
 CNAME=${CNAME:-showoff}
 TRAINING=${TRAINING:-$(basename "$DIR")}
 RUNTIME=${RUNTIME:-$(command -v docker)}


### PR DESCRIPTION
- Bump showoff to 0.20.3

This required a minor patch to showiff, in order to correct the paths to images. Credits to @RincewindsHat 

- Bump to wkhtmltox to 0.12.5 and vendor package in the repo

I vendored the wkhtmltox package since the project repo is no longer maintained and read-only. Let's have a copy here just to be save.