### PR TITLE
Remove all CVEs from Showoff image by updating Dockerfile

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.deb filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .*
+!.gitignore
+!.gitattributes
 static
 stats
 trainer

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,8 @@ RUN set -ex; \
     && rm -f /tmp/wkhtmltox.deb
 
 # Install showoff Gem
-ARG showoff_version=0.20.3
+ARG showoff_version=0.20.4
 RUN gem install showoff --version="$showoff_version"
-
-ADD extras/showoff.patch /tmp/showoff.patch
-
-RUN cd /var/lib/gems/*/gems/showoff-*/lib \
-	&& patch -p1 < /tmp/showoff.patch
 
 EXPOSE 9090
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,12 @@ RUN set -ex; \
 
 # Install showoff Gem
 ARG showoff_version=0.20.4
-RUN gem install showoff --version="$showoff_version"
-
-# uri v0.11.0 (installed as dependency for showoff) contains a CVE
-# so we upgrade, delete the default, and clean up
-RUN gem update uri && rm /usr/lib/ruby/gems/3.1.0/specifications/default/uri-0.11.0.gemspec && gem cleanup uri
+RUN set -ex; \
+    gem install showoff --version="$showoff_version" \
+    # uri v0.11.0 (installed as dependency for showoff) contains CVE-2023-28755
+    # so we upgrade and delete the default manually. This might be removed in the future
+    # Note that the Ruby 3.1.0 path might change when updating the distro
+    && GEM_HOME=/usr/lib/ruby/gems/3.1.0/ gem install --default uri; rm -f /usr/lib/ruby/gems/3.1.0/specifications/default/uri-0.11*;
 
 EXPOSE 9090
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/ubuntu:focal
+FROM docker.io/ubuntu:lunar
 LABEL maintainer="support@netways.de"
 
 WORKDIR /training
@@ -17,8 +17,7 @@ RUN set -ex; \
       xz-utils \
       zlib1g \
       zlib1g-dev \
-      libssl1.1 \
-      libssl-dev \
+      libssl3 \
       libxrender-dev \
       libx11-dev \
       libxext-dev \
@@ -32,10 +31,10 @@ RUN set -ex; \
   && rm -r /var/lib/apt/lists/*
 
 # wkhtmltopdf needs a patched QT version
-ADD vendor/wkhtmltox_0.12.5-1.focal_amd64.deb /tmp/wkhtmltox_0.12.5-1.focal_amd64.deb
+ADD vendor/wkhtmltox_0.12.6.1-2.jammy_amd64.deb /tmp/wkhtmltox.deb
 RUN set -ex; \
-    dpkg -i /tmp/wkhtmltox_0.12.5-1.focal_amd64.deb \
-    && rm -f /tmp/wkhtmltox_0.12.5-1.focal_amd64.deb
+    dpkg -i /tmp/wkhtmltox.deb \
+    && rm -f /tmp/wkhtmltox.deb
 
 # Install showoff Gem
 ARG showoff_version=0.20.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN set -ex; \
 ARG showoff_version=0.20.4
 RUN gem install showoff --version="$showoff_version"
 
+# uri v0.11.0 (installed as dependency for showoff) contains a CVE
+# so we upgrade, delete the default, and clean up
+RUN gem update uri && rm /usr/lib/ruby/gems/3.1.0/specifications/default/uri-0.11.0.gemspec && gem cleanup uri
+
 EXPOSE 9090
 
 CMD ["showoff", "serve"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 RUNTIME?=docker
-VERSION?=0.20.3
+VERSION?=0.20.4
 
 image:
 	$(RUNTIME) build --pull -t docker.io/netways/showoff:$(VERSION) .

--- a/README.md
+++ b/README.md
@@ -120,13 +120,13 @@ make image RUNTIME=podman
 ### Run showoff
 
 ```bash
-docker run -it --rm -v "$PWD:/training" -p "9090:9090" netways/showoff:0.20.3
+docker run -it --rm -v "$PWD:/training" -p "9090:9090" netways/showoff:0.20.4
 ```
 
 ### Build static html files
 
 ```bash
-docker run -it --rm -v "$PWD:/training" netways/showoff:0.20.3 \
+docker run -it --rm -v "$PWD:/training" netways/showoff:0.20.4 \
   showoff static print
 ```
 
@@ -134,7 +134,7 @@ docker run -it --rm -v "$PWD:/training" netways/showoff:0.20.3 \
 
 ```bash
 docker run -it --rm -v "$PWD:/training" \
-  netways/showoff:0.20.3 \
+  netways/showoff:0.20.4 \
   wkhtmltopdf -s A5 --print-media-type \
   --footer-left \[page\] --footer-right '© NETWAYS' \
   static/index.html test.pdf

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ resides here.
 
 ## How to use
 
+Install and initialize `git-lfs` on your system.
+
 ### 1. Add global resource directory to your project
 
 The global resource dir is introduced by using git subtree mechanism. This keeps the training repository clear from

--- a/vendor/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+++ b/vendor/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee88d74834bdec650f7432c7d3ef1c981e42ae7a762a75a01f7f5da59abc18d5
+size 17352866

--- a/wizard.sh
+++ b/wizard.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 DIR=$(pwd)
 CLANG=${CLANG:-C.UTF-8}
-IMAGE=${IMAGE:-netways/showoff:0.20.3}
+IMAGE=${IMAGE:-netways/showoff:0.20.4}
 CNAME=${CNAME:-showoff}
 TRAINING=${TRAINING:-$(basename "$DIR")}
 RUNTIME=${RUNTIME:-$(command -v docker)}

--- a/wizard.sh
+++ b/wizard.sh
@@ -33,21 +33,21 @@ printhandouts () {
   echo -e "\n--- RUN SHOWOFF STATIC FOR HANDOUTS ---"
   execdocker "showoff static print"
   echo -e "\n--- RUN WKHTMLTOPDF FOR HANDOUTS ---"
-  execdocker "wkhtmltopdf --load-error-handling ignore -s A5 --print-media-type --footer-left [page] --footer-right ©NETWAYS static/index.html ${TRAINING}_${1}-handouts.pdf"
+  execdocker "wkhtmltopdf --enable-local-file-access --load-error-handling ignore -s A5 --print-media-type --footer-left [page] --footer-right ©NETWAYS static/index.html ${TRAINING}_${1}-handouts.pdf"
 }
 
 printexercises () {
   echo -e "\n--- RUN SHOWOFF STATIC FOR EXERCISES ---"
   execdocker "showoff static supplemental exercises"
   echo -e "\n--- RUN WKHTMLTOPDF FOR EXERCISES ---"
-  execdocker "wkhtmltopdf --load-error-handling ignore -s A5 --print-media-type --footer-left [page] --footer-right ©NETWAYS static/index.html ${TRAINING}_${1}-exercises.pdf"
+  execdocker "wkhtmltopdf --enable-local-file-access --load-error-handling ignore -s A5 --print-media-type --footer-left [page] --footer-right ©NETWAYS static/index.html ${TRAINING}_${1}-exercises.pdf"
 }
 
 printsolutions () {
   echo -e "\n--- RUN SHOWOFF STATIC FOR SOLUTIONS ---"
   execdocker "showoff static supplemental solutions"
   echo -e "\n--- RUN WKHTMLTOPDF FOR SOLUTIONS ---"
-  execdocker "wkhtmltopdf --load-error-handling ignore -s A5 --print-media-type --footer-left [page] --footer-right ©NETWAYS static/index.html ${TRAINING}_${1}-solutions.pdf"
+  execdocker "wkhtmltopdf --enable-local-file-access --load-error-handling ignore -s A5 --print-media-type --footer-left [page] --footer-right ©NETWAYS static/index.html ${TRAINING}_${1}-solutions.pdf"
 }
 
 setlayout () {


### PR DESCRIPTION
While playing around with `docker scout` I managed to cut down the CVEs reported for our `netways/showoff` image from 249 to 0:

- Updated base image from `ubuntu:focal` to `ubuntu:lunar`
- Vendored `libssl1.1` since it's not available in the official repos for Ubuntu 23 anymore
- Upgraded `uri` gem from `v0.11.0` installed as dependency of `showoff` gem to `v0.12.2` and wiped the old version as it contained a CVE

Comparison old vs new (I tagged the new version `netways/showoff:scout` locally but haven't pushed yet:

```console
➜ docker scout quickview -o old.txt netways/showoff:0.20.3
➜ cat old.txt

  Your image  netways/showoff:0.20.3  │    1C    23H   136M    85L     4?
  Base image  ubuntu:20.04            │    0C     0H     6M    10L
  Refreshed base image  ubuntu:20.04  │    0C     0H     0M     7L
                                      │                  -6     -3
  Updated base image  ubuntu:23.04    │    0C     0H     0M     0L
                                      │                  -6    -10

  │ Know more about vulnerabilities:
  │    docker scout cves netways/showoff:0.20.3
  │ Know more about base image update recommendations:
  │    docker scout recommendations netways/showoff:0.20.3
```

```console
➜ docker scout quickview -o new.txt netways/showoff:scout
➜ cat new.txt

  Your image  netways/showoff:scout  │    0C     0H     0M     0L
  Base image  ubuntu:23.04           │    0C     0H     0M     0L
  Updated base image  ubuntu:23.10   │    0C     0H     0M     0L
                                     │

  │ Know more about vulnerabilities:
  │    docker scout cves netways/showoff:scout
  │ Know more about base image update recommendations:
  │    docker scout recommendations netways/showoff:scout
```

@martialblog do we need to take care of anything else when vendoring `libssl1.1`? I never vendored anything before.