### PR TITLE
Remove use of git-lfs and change to download wkhtmltox releases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,9 +31,10 @@ RUN set -ex; \
   && rm -r /var/lib/apt/lists/*
 
 # wkhtmltopdf needs a patched QT version
-ADD vendor/wkhtmltox_0.12.6.1-2.jammy_amd64.deb /tmp/wkhtmltox.deb
+ARG wkhtmltox_url=https://github.com/NETWAYS/training-global/releases/download/v0.20.4/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
 RUN set -ex; \
-    dpkg -i /tmp/wkhtmltox.deb \
+    curl -sSL "${wkhtmltox_url}" --output /tmp/wkhtmltox.deb \
+    && dpkg -i /tmp/wkhtmltox.deb \
     && rm -f /tmp/wkhtmltox.deb
 
 # Install showoff Gem

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ resides here.
 
 ## How to use
 
-Install and initialize `git-lfs` on your system.
-
 ### 1. Add global resource directory to your project
 
 The global resource dir is introduced by using git subtree mechanism. This keeps the training repository clear from

--- a/vendor/wkhtmltox_0.12.5-1.focal_amd64.deb
+++ b/vendor/wkhtmltox_0.12.5-1.focal_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e46fb0fe265ad8aed99c8a53020aaf2a14b50ca9c0f704ba00ebaad737152489
-size 15718564

--- a/vendor/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+++ b/vendor/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee88d74834bdec650f7432c7d3ef1c981e42ae7a762a75a01f7f5da59abc18d5
-size 17352866


### PR DESCRIPTION
 - git-lfs does not work with git subtree, which we use for the downstream trainings
 - Right now, I think (ab)using the Release artifacts is a valid solution. Might change in the future

Fixes #13 