### PR TITLE
Add default licence to be included into printed version

### DIFF
--- a/pre/licence/00_licence.md
+++ b/pre/licence/00_licence.md
@@ -1,0 +1,27 @@
+!SLIDE printonly
+
+# Licence
+
+This work is licensed under a Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0) License.
+
+This is a human-readable summary of (and not a substitute for) the license.
+
+You are free to:
+
+* Share — copy and redistribute the material in any medium or format
+* Adapt — remix, transform, and build upon the material
+
+Under the following terms:
+
+* Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made. You may do so in any reasonable manner, but not in any way that suggests the licensor endorses you or your use.
+
+* NonCommercial — You may not use the material for commercial purposes.
+* ShareAlike — If you remix, transform, or build upon the material, you must distribute your contributions under the same license as the original.
+* No additional restrictions — You may not apply legal terms or technological measures that legally restrict others from doing anything the license permits.
+
+The licensor cannot revoke these freedoms as long as you follow the license terms.
+
+Full Licence:
+
+* https://creativecommons.org/licenses/by-nc-sa/4.0/
+* https://creativecommons.org/licenses/by-nc-sa/4.0/deed.de

--- a/showoff.json
+++ b/showoff.json
@@ -18,7 +18,7 @@
   "sections": [
     {"section": "global/pre/netways/title"},
     {"section": "global/pre/toc"},
-    {"section": "trainer"},
+    {"section": "global/pre/licence"},
     {"section": "global/pre/netways/about"},
     {"section": "global/pre/hints"},
 


### PR DESCRIPTION
This change adds a `printonly` page including the default licence to the PDF. 

Individual changes to the licence can be done in downstream trainings by changing the either the text or including a different licence.